### PR TITLE
Introduce Access Modal. Part of UICHKIN-32 and UICHKOUT-433

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ export default class ServicePoints extends React.Component {
       return ServicePoints;
     }
 
-    if (event === coreEvents.SELECT_MODULE && data.name && data.name.match(/checkin|checkout/)) {
+    if (event === coreEvents.SELECT_MODULE &&
+      !curServicePoint &&
+      data.name && data.name.match(/checkin|checkout/)) {
       return AccessModal;
     }
 

--- a/index.js
+++ b/index.js
@@ -4,18 +4,23 @@ import PropTypes from 'prop-types';
 import coreEvents from '@folio/stripes-core/src/events';
 import events from './events';
 import ServicePointsModal from './lib/ServicePointsModal';
+import AccessModal from './lib/AccessModal';
 
 export default class ServicePoints extends React.Component {
   static propTypes = {
     stripes: PropTypes.object,
   };
 
-  static eventHandler(event, stripes) {
+  static eventHandler(event, stripes, data) {
     const curServicePoint = get(stripes, ['user', 'user', 'curServicePoint']);
 
     if (event === events.CHANGE_SERVICE_POINT ||
       (event === coreEvents.LOGIN && !curServicePoint)) {
       return ServicePoints;
+    }
+
+    if (event === coreEvents.SELECT_MODULE && data.name && data.name.match(/checkin|checkout/)) {
+      return AccessModal;
     }
 
     return null;

--- a/lib/AccessModal/AccessModal.js
+++ b/lib/AccessModal/AccessModal.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Modal from '@folio/stripes-components/lib/Modal';
+import Button from '@folio/stripes-components/lib/Button';
+import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
+
+class AccessModal extends React.Component {
+  static propTypes = {
+    stripes: PropTypes.object,
+    data: PropTypes.object,
+  };
+
+  constructor() {
+    super();
+    this.state = { open: true };
+  }
+
+  closeModal() {
+    this.setState({ open: false });
+  }
+
+  render() {
+    const { stripes, data } = this.props;
+    const { displayName } = data;
+
+    return (
+      <Modal
+        dismissible
+        onClose={() => this.closeModal()}
+        open={this.state.open}
+        label={stripes.intl.formatMessage({ id: 'ui-servicepoints.accessDenied.title' })}
+      >
+        <p><SafeHTMLMessage id="ui-servicepoints.accessDenied.message" values={{ displayName }} /></p>
+        <Col xs={12}>
+          <Row end="xs">
+            <Button buttonStyle="primary" onClick={() => this.closeModal()}>
+              <SafeHTMLMessage id="ui-servicepoints.accessDenied.close" />
+            </Button>
+          </Row>
+        </Col>
+      </Modal>
+    );
+  }
+}
+
+export default AccessModal;

--- a/lib/AccessModal/index.js
+++ b/lib/AccessModal/index.js
@@ -1,0 +1,1 @@
+export { default } from './AccessModal';

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@folio/stripes-components": "^3.0.0",
+    "@folio/react-intl-safe-html": "^1.0.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",
     "react-router-dom": "^4.0.0"

--- a/translations/ui-servicepoints/en.json
+++ b/translations/ui-servicepoints/en.json
@@ -1,5 +1,8 @@
 {
   "meta.title": "Service points",
   "selectServicePoint": "Select service point",
-  "userDropdown.switchServicePoint": "Switch service point"
+  "userDropdown.switchServicePoint": "Switch service point",
+  "accessDenied.title": "Access Denied",
+  "accessDenied.message": "You must select a service point to access the <strong>{displayName}</strong>. Please add one or more service points to your user record in the <strong>Users</strong> app. Contact an administrator if you do not have access to this feature.",
+  "accessDenied.close": "Close"
 }


### PR DESCRIPTION
This PR adds a new `AccessModal` component which will be initialized when the `SELECT_MODULE` event is triggered and the current service point is not preset.
This is a continuation of work from:
 
https://github.com/folio-org/stripes-core/pull/392

One questionable part is the hard coded names of modules for which we want this to be triggered for:

https://github.com/folio-org/ui-servicepoints/compare/UICHKOUT-433?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcR24

One way we could clean that up is to perhaps introduce a new prop in `stripes` config in both `ui-checkout` and `ui-checkin`?


 