### PR TITLE
UIU-551: ServicePoints: Added onClose prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,5 @@
 
 * First release.
 * Add ability to close SP Modal. Part of UIU-628.
+* Added `onClose` callback to `ServicePoints`. Supports UIU-551.
+

--- a/events.js
+++ b/events.js
@@ -1,5 +1,0 @@
-const events = {
-  CHANGE_SERVICE_POINT: 'CHANGE_SERVICE_POINT'
-};
-
-export default events;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ import { get } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import coreEvents from '@folio/stripes-core/src/events';
-import events from './events';
 import ServicePointsModal from './lib/ServicePointsModal';
 import AccessModal from './lib/AccessModal';
 
@@ -24,7 +23,7 @@ export default class ServicePoints extends React.Component {
     const curServicePoint = get(stripes, ['user', 'user', 'curServicePoint']);
     const spList = get(stripes, ['user', 'user', 'servicePoints'], []);
 
-    if (event === events.CHANGE_SERVICE_POINT ||
+    if (event === coreEvents.CHANGE_SERVICE_POINT ||
       (event === coreEvents.LOGIN && !curServicePoint && spList.length)) {
       return ServicePoints;
     }

--- a/index.js
+++ b/index.js
@@ -9,6 +9,11 @@ import AccessModal from './lib/AccessModal';
 export default class ServicePoints extends React.Component {
   static propTypes = {
     stripes: PropTypes.object,
+    onClose: PropTypes.func,
+  };
+
+  static defaultProps = {
+    onClose: () => {},
   };
 
   static checkServicePoints(stripes) {
@@ -40,6 +45,7 @@ export default class ServicePoints extends React.Component {
 
   closeModal() {
     this.setState({ open: false });
+    this.props.onClose();
   }
 
   render() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/servicepoints",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Service Points handler for Stripes",
   "repository": "folio-org/ui-servicepoints",
   "publishConfig": {


### PR DESCRIPTION
Added an `onClose` callback to use when wanting to show the service points modal via an external trigger.

[Usage example is here.](https://github.com/folio-org/ui-users/compare/uiu-551?expand=1)