### PR TITLE
Replace stripes.intl with FormattedMessage

### DIFF
--- a/src/AccessModal/AccessModal.js
+++ b/src/AccessModal/AccessModal.js
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Col, Modal, Row } from '@folio/stripes/components';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
+import { FormattedMessage } from 'react-intl';
 
 class AccessModal extends React.Component {
   static propTypes = {
-    stripes: PropTypes.object,
     data: PropTypes.object,
   };
 
@@ -19,7 +19,7 @@ class AccessModal extends React.Component {
   }
 
   render() {
-    const { stripes, data } = this.props;
+    const { data } = this.props;
     const { displayName } = data;
 
     return (
@@ -27,7 +27,7 @@ class AccessModal extends React.Component {
         dismissible
         onClose={() => this.closeModal()}
         open={this.state.open}
-        label={stripes.intl.formatMessage({ id: 'ui-servicepoints.accessDenied.title' })}
+        label={<FormattedMessage id="ui-servicepoints.accessDenied.title" />}
       >
         <p><SafeHTMLMessage id="ui-servicepoints.accessDenied.message" values={{ displayName }} /></p>
         <Col xs={12}>

--- a/src/ServicePointsModal/ServicePointsModal.js
+++ b/src/ServicePointsModal/ServicePointsModal.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { sortBy, get } from 'lodash';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 import { setCurServicePoint } from '@folio/stripes/core';
 import { Button, Col, Modal, Row } from '@folio/stripes/components';
 
@@ -25,7 +26,13 @@ class ServicePointsModal extends React.Component {
     const curServicePoint = get(stripes, ['user', 'user', 'curServicePoint'], {});
 
     return (
-      <Modal open={open} onClose={onClose} closeOnBackgroundClick dismissible label={stripes.intl.formatMessage({ id: 'ui-servicepoints.selectServicePoint' })}>
+      <Modal
+        open={open}
+        onClose={onClose}
+        closeOnBackgroundClick
+        dismissible
+        label={<FormattedMessage id="ui-servicepoints.selectServicePoint" />}
+      >
         <Col xs={12}>
           <Row>
             {


### PR DESCRIPTION
`stripes.intl` is deprecated and will soon be removed from `stripes-core`.

Updates to the preferred `<FormattedMessage>` usage.