### PR TITLE
remove unnecessary aria-label attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-servicepoints
 
+## 1.3.1 (IN PROGRESS)
+
+* Remove unnecessary `aria-label` attribute.
+
 ## [1.3.0](https://github.com/folio-org/ui-servicepoints/tree/v1.3.0) (2019-01-25)
 [Full Changelog](https://github.com/folio-org/ui-servicepoints/compare/v1.2.0...v1.3.0)
 

--- a/src/ServicePointsModal/ServicePointsModal.js
+++ b/src/ServicePointsModal/ServicePointsModal.js
@@ -41,7 +41,6 @@ class ServicePointsModal extends React.Component {
                   buttonStyle={(curServicePoint.id === sp.id) ? 'primary' : 'default'}
                   key={sp.id}
                   id={`service-point-btn-${index}`}
-                  arial-label={sp.name}
                   fullWidth
                   onClick={() => this.setCurrentServicePoint(sp)}
                 >


### PR DESCRIPTION
The `aria-label` attribute was misspelled, but also unnecessary because
the button's child element contains the same value.