### PR TITLE
Use new actAs format to define module type.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   },
   "main": "src/index.js",
   "stripes": {
-    "type": "handler",
+    "actsAs": [
+      "handler"
+    ],
     "handlerName": "eventHandler",
     "displayName": "ui-servicepoints.meta.title",
     "links": {


### PR DESCRIPTION
This PR uses a new `actAs` format to specify the type of the module. This should fix the issue with "Switch service point" showing up twice.