### PR TITLE
updating ui-servicepoints dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,24 +33,24 @@
     "test": "echo 'placeholder. no tests implemented'"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^3.2.1",
-    "@folio/stripes": "^3.0.0",
+    "@folio/eslint-config-stripes": "^5.1.0",
+    "@folio/stripes": "^4.0.0",
     "@folio/stripes-cli": "^1.3.1",
-    "babel-eslint": "^9.0.0",
-    "eslint": "^5.5.0",
+    "babel-eslint": "^10.0.3",
+    "eslint": "^6.2.1",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
-    "react-intl": "^2.4.0"
+    "react-intl": "^4.5.3"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^1.0.0",
+    "@folio/react-intl-safe-html": "^2.0.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^3.0.0",
+    "@folio/stripes": "^4.0.0",
     "react": "*",
-    "react-intl": "^2.4.0",
+    "react-intl": "^4.5.3",
     "react-router-dom": "^4.3.1"
   }
 }


### PR DESCRIPTION
Ui-servicepoints is currently using old versions of several dependencies,
including out-of-date versions of:
@folio/stripes,
@folio/react-intl-safe-html, and
react-intl
various linting modules

This is causing significant problems when you try to pull a local copy
of this module and use it in a development environment.  I've updated
the listed packages to more recent versions in the package-json, this
seems to have fixed the numerous errors this module was throwing when
used with the latest platform-core snapshot.