### PR TITLE
UIREQ-440:  error in UI-requests when no service point selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [2.1.0] (IN PROGRESS)
 
+*Error accessing Requests when user doesn't have a service point selected.  Fixes UIREQ-440.
+
 ## [2.0.0](https://github.com/folio-org/ui-servicepoints/tree/v2.0.0) (2020-03-12)
 [Full Changelog](https://github.com/folio-org/ui-servicepoints/compare/v1.4.2...v2.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change history for ui-servicepoints
 
+## [2.1.0] (IN PROGRESS)
+
 ## [2.0.0](https://github.com/folio-org/ui-servicepoints/tree/v2.0.0) (2020-03-12)
 [Full Changelog](https://github.com/folio-org/ui-servicepoints/compare/v1.4.2...v2.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [2.1.0] (IN PROGRESS)
 
-*Error accessing Requests when user doesn't have a service point selected.  Fixes UIREQ-440.
+* Error accessing Requests when user doesn't have a service point selected.  Fixes UIREQ-440.
 
 ## [2.0.0](https://github.com/folio-org/ui-servicepoints/tree/v2.0.0) (2020-03-12)
 [Full Changelog](https://github.com/folio-org/ui-servicepoints/compare/v1.4.2...v2.0.0)

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ export default class ServicePoints extends React.Component {
 
     if (event === coreEvents.SELECT_MODULE &&
       !curServicePoint &&
-      data.name && data.name.match(/checkin|checkout/)) {
+      data.name && data.name.match(/checkin|checkout|requests/)) {
       return AccessModal;
     }
 


### PR DESCRIPTION
Added the name of the requests module to the line of code that
lists modules that should not load if there is no service point
selected.  This seems to have fixed the problem.

Ref: [UIREQ-440](https://issues.folio.org/browse/UIREQ-440)