### PR TITLE
UISP-20: increment @folio/stripes to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.1.0 (IN PROGRESS)
 
+* Upgraded dependencies to stripes 5.  Addresses UISP-20.
 * Add test coverage . Refs UISP-11.
 
 ## [3.0.0](https://github.com/folio-org/ui-servicepoints/tree/v3.0.0) (2020-06-10)

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "miragejs": "^0.1.32",
     "@folio/stripes": "^5.0.0",
-    "@folio/stripes-core": "^5.0.0",
+    "@folio/stripes-core": "^6.0.0",
     "core-js": "^3.6.4",
     "@folio/stripes-components": "~8.0.0",
     "@folio/stripes-connect": "~6.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^4.0.0",
+    "@folio/stripes": "^5.0.0",
     "react": "*",
     "react-dom": "*",
     "react-router": "^5.2.0",


### PR DESCRIPTION
Testing has been using stripes five and associated modules
since written (I wrote them recently).  I just upgraded
The version of stripes in dev dependencies.

Refs: https://issues.folio.org/browse/UISP-20