### PR TITLE
use stripes v5 compatible deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-servicepoints
 
+## 4.0.1 IN PROGRESS
+
+* Use `react-intl` and `react-intl-safe-html` version compatible with `stripes` `v5`.
+
 ## [4.0.0](https://github.com/folio-org/ui-servicepoints/tree/v4.0.0) (2020-10-14)
 [Full Changelog](https://github.com/folio-org/ui-servicepoints/compare/v3.0.0...v4.0.0)
 

--- a/package.json
+++ b/package.json
@@ -54,13 +54,13 @@
     "mocha": "^8.0.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "react-intl": "^4.5.3",
+    "react-intl": "^5.7.0",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "sinon": "^7.2.2"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^2.0.0",
+    "@folio/react-intl-safe-html": "^3.0.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0"
   },
@@ -68,8 +68,8 @@
     "@folio/stripes": "^5.0.0",
     "react": "*",
     "react-dom": "*",
+    "react-intl": "^5.7.0",
     "react-router": "^5.2.0",
-    "react-intl": "^4.5.3",
     "react-router-dom": "^5.2.0"
   }
 }


### PR DESCRIPTION
The `react-intl` and `react-intl-safe-html` versions in the `4.0.0`
release are not compatible with the peer-dependency expectations of
`@folio/stripes` `v5.0.0`.