### PR TITLE
UISP-26 replace SafeHTMLMessage with FormattedMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 6.1.0 (IN PROGRESS)
 
+* Replace `SafeHTMLMessage` with `FormattedMessage`. Refs UISP-26.
+
 ## [6.0.0](https://github.com/folio-org/ui-servicepoints/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-servicepoints/compare/v5.0.1...v6.0.0)
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "sinon": "^7.2.2"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^3.0.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0"
   },

--- a/src/AccessModal/AccessModal.js
+++ b/src/AccessModal/AccessModal.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Col, Modal, Row } from '@folio/stripes/components';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { FormattedMessage } from 'react-intl';
 
 class AccessModal extends React.Component {
@@ -31,11 +30,11 @@ class AccessModal extends React.Component {
 
         label={<FormattedMessage id="ui-servicepoints.accessDenied.title" />}
       >
-        <p><SafeHTMLMessage id="ui-servicepoints.accessDenied.message" values={{ displayName }} /></p>
+        <p><FormattedMessage id="ui-servicepoints.accessDenied.message" values={{ displayName }} /></p>
         <Col xs={12}>
           <Row end="xs">
             <Button data-test-access-modal-close buttonStyle="primary" onClick={() => this.closeModal()}>
-              <SafeHTMLMessage id="ui-servicepoints.accessDenied.close" />
+              <FormattedMessage id="ui-servicepoints.accessDenied.close" />
             </Button>
           </Row>
         </Col>


### PR DESCRIPTION
Everythign `SafeHTMLMessage` can do `FormattedMessage` can do too,
without an extra package.

Refs [UISP-26](https://issues.folio.org/browse/UISP-26), [STRIPES-754](https://issues.folio.org/browse/STRIPES-754)