### PR TITLE
UISP-53 handle dynamically-defined servicepoints consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-servicepoints
 
+## IN PROGRESS
+
+* *BREAKING* Handle dynamically-defined servicepoint consumers. Refs UISP-53.
+
 ## [8.0.0](https://github.com/folio-org/ui-servicepoints/tree/v8.0.0) (2025-03-14)
 [Full Changelog](https://github.com/folio-org/ui-servicepoints/compare/v7.2.0...v8.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change history for ui-servicepoints
 
-## IN PROGRESS
+## [8.1.0] IN PROGRESS
 
-* *BREAKING* Handle dynamically-defined servicepoint consumers. Refs UISP-53.
+* Handle dynamically-defined servicepoint consumers. Refs UISP-53.
 
 ## [8.0.0](https://github.com/folio-org/ui-servicepoints/tree/v8.0.0) (2025-03-14)
 [Full Changelog](https://github.com/folio-org/ui-servicepoints/compare/v7.2.0...v8.0.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/servicepoints",
-  "version": "9.0.0",
+  "version": "8.0.0",
   "description": "Service Points handler for Stripes",
   "repository": "folio-org/ui-servicepoints",
   "publishConfig": {
@@ -57,7 +57,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^10.1.0",
+    "@folio/stripes": "^10.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-intl": "^7.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/servicepoints",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "Service Points handler for Stripes",
   "repository": "folio-org/ui-servicepoints",
   "publishConfig": {
@@ -57,7 +57,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^10.0.0",
+    "@folio/stripes": "^10.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-intl": "^7.1.5",

--- a/src/eventHandlers.js
+++ b/src/eventHandlers.js
@@ -34,7 +34,7 @@ export const servicePointIsRequired = (stripes, data) => {
 
   // :) search for modules defining stripes.actsAs[..., 'servicePointsConsumer']
   // and return true if one matches the destination module
-  for (const mod of stripes?.servicepointsConsumer || []) {
+  for (const mod of stripes.modules?.servicepointsConsumer || []) {
     if (mod.module === data.module) {
       return true;
     }

--- a/src/eventHandlers.js
+++ b/src/eventHandlers.js
@@ -34,7 +34,7 @@ export const servicePointIsRequired = (stripes, data) => {
 
   // :) search for modules defining stripes.actsAs[..., 'servicePointsConsumer']
   // and return true if one matches the destination module
-  for (const mod of stripes.modules?.servicepointsConsumer || []) {
+  for (const mod of stripes?.servicepointsConsumer || []) {
     if (mod.module === data.module) {
       return true;
     }

--- a/src/eventHandlers.js
+++ b/src/eventHandlers.js
@@ -34,7 +34,7 @@ export const servicePointIsRequired = (stripes, data) => {
 
   // :) search for modules defining stripes.actsAs[..., 'servicePointsConsumer']
   // and return true if one matches the destination module
-  for (const mod of stripes.modules.servicepointsConsumer || []) {
+  for (const mod of stripes.modules?.servicepointsConsumer || []) {
     if (mod.module === data.module) {
       return true;
     }

--- a/src/eventHandlers.test.js
+++ b/src/eventHandlers.test.js
@@ -5,6 +5,7 @@ import ChangeServicePoint from './ChangeServicePoint';
 import {
   handleCheckServicePoints,
   handleEvent,
+  servicePointIsRequired
 } from './eventHandlers';
 
 describe('handleCheckServicePoints', () => {
@@ -109,50 +110,38 @@ describe('handleEvent', () => {
   });
 });
 
+describe('servicePointIsRequired', () => {
+  describe('returns true for legacy applications', () => {
+    it('checkin', () => {
+      expect(servicePointIsRequired({}, { name: 'checkin' })).toBe(true);
+    });
 
+    it('checkout', () => {
+      expect(servicePointIsRequired({}, { name: 'checkout' })).toBe(true);
+    });
 
-// export const handleEvent = (event, stripes, data) => {
-//   console.log('ServicePoints.eventHandler')
-//   let curServicePoint = get(stripes, ['okapi', 'currentUser', 'curServicePoint']);
-//   let servicePoints = get(stripes, ['okapi', 'currentUser', 'servicePoints'], []);
+    it('requests', () => {
+      expect(servicePointIsRequired({}, { name: 'requests' })).toBe(true);
+    });
+  });
 
-//   // on login, parse the login response for service point info
-//   // if curServicePoint is already set, we must be reloading an existing session
-//   // in wich case we don't need to parse that response
-//   if (event === coreEvents.LOGIN && !curServicePoint) {
-//     // handleLoginWithoutServicePoint
-//     servicePoints = get(stripes, ['okapi', 'loginData', 'servicePointsUser', 'servicePoints'], []);
-//     const loginDefaultSPId = get(stripes, ['okapi', 'loginData', 'servicePointsUser', 'defaultServicePointId']);
-//     curServicePoint = (!loginDefaultSPId && servicePoints.length === 1) ?
-//       servicePoints[0] :
-//       servicePoints.find(sp => sp.id === loginDefaultSPId);
+  it('returns true for applications of type "servicepointsConsumer"', () => {
+    const stripes = {
+      modules: {
+        servicepointsConsumer: [{ module: 'foo' }]
+      }
+    };
+    const data = { module: 'foo' };
+    expect(servicePointIsRequired(stripes, data)).toBe(true);
+  });
 
-//     // persist to storage
-//     updateUser(stripes.store, {
-//       curServicePoint,
-//       servicePoints,
-//     });
-
-//     stripes.updateUser({
-//       curServicePoint,
-//       servicePoints,
-//     });
-//   }
-
-//   // show the "change service point modal" when
-//   // 1. the CHANGE_SERVICE_POINT event fires (duh)
-//   // 2. on login if the user has SPs but not a current SP
-//   if (event === coreEvents.CHANGE_SERVICE_POINT ||
-//     (event === coreEvents.LOGIN && !curServicePoint && servicePoints.length)) {
-//     return ChangeServicePoint;
-//   }
-
-//   // changing apps when
-//   if (event === coreEvents.SELECT_MODULE &&
-//     !curServicePoint &&
-//     data.name && data.name.match(/checkin|checkout|requests/)) {
-//     return AccessModal;
-//   }
-
-//   return null;
-// };
+  it('returns false for applications without type "servicepointsConsumer"', () => {
+    const stripes = {
+      modules: {
+        servicepointsConsumer: [{ module: 'foo' }]
+      }
+    };
+    const data = { module: 'bar' };
+    expect(servicePointIsRequired(stripes, data)).toBe(true);
+  });
+});

--- a/src/eventHandlers.test.js
+++ b/src/eventHandlers.test.js
@@ -142,6 +142,6 @@ describe('servicePointIsRequired', () => {
       }
     };
     const data = { module: 'bar' };
-    expect(servicePointIsRequired(stripes, data)).toBe(true);
+    expect(servicePointIsRequired(stripes, data)).toBe(false);
   });
 });


### PR DESCRIPTION
When handling `SELECT_MODULE` events, inspect `stripes.modules.servicepointsConsumer` to see if there is a value that matches the destination application. 

This allows modules to add `servicepointsConsumer` to the `stripes.actsAs` array in their `package.json` file and for this module to discover that without any hard-coded coupling such as the legacy hard-coded list of checkin, checkout, and requests.

* See also https://github.com/folio-org/stripes-core/pull/1671

Refs [UISP-52](https://folio-org.atlassian.net/browse/UISP-52), [UISP-53](https://folio-org.atlassian.net/browse/UISP-53)