### PR TITLE
UISP-53: Read a list of modules from `stripes.metadata` instead of a hard-coded list to display the `Access Denied` modal when a user does not have a service point assigned.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-servicepoints
 
+## [9.0.0] IN PROGRESS
+
+* *BREAKING* Read a list of modules from `stripes.metadata` instead of a hard-coded list to display the "Access Denied" modal when a user does not have a service point assigned.
+
 ## [8.0.0](https://github.com/folio-org/ui-servicepoints/tree/v8.0.0) (2025-03-14)
 [Full Changelog](https://github.com/folio-org/ui-servicepoints/compare/v7.2.0...v8.0.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/servicepoints",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "Service Points handler for Stripes",
   "repository": "folio-org/ui-servicepoints",
   "publishConfig": {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,1 @@
+export const SERVICE_POINTS_KEY = 'servicepoints';

--- a/src/eventHandlers.js
+++ b/src/eventHandlers.js
@@ -2,6 +2,7 @@ import { coreEvents, updateUser } from '@folio/stripes/core';
 
 import AccessModal from './AccessModal';
 import ChangeServicePoint from './ChangeServicePoint';
+import { SERVICE_POINTS_KEY } from './constants';
 
 /**
  * handleCheckServicePoints
@@ -30,7 +31,6 @@ export const handleCheckServicePoints = (stripes) => {
  * @returns null, or a Component in order to prevent the event from propagating
  */
 export const handleEvent = (event, stripes, data) => {
-  const APP_LIST_THAT_REQUIRES_SERVICE_POINT = ['checkin', 'checkout', 'requests'];
   let curServicePoint = stripes?.okapi?.currentUser?.curServicePoint;
   let servicePoints = stripes?.okapi?.currentUser?.servicePoints ?? [];
 
@@ -60,10 +60,13 @@ export const handleEvent = (event, stripes, data) => {
     return ChangeServicePoint;
   }
 
+  const appMetadata = stripes?.metadata?.[data?.name];
+  const requiresServicePoint = appMetadata?.subscribesTo?.includes(SERVICE_POINTS_KEY);
+
   // changing apps when
   if (event === coreEvents.SELECT_MODULE &&
     !curServicePoint &&
-    data.name && APP_LIST_THAT_REQUIRES_SERVICE_POINT.includes(data.name)) {
+    requiresServicePoint) {
     return AccessModal;
   }
 

--- a/src/eventHandlers.test.js
+++ b/src/eventHandlers.test.js
@@ -92,6 +92,11 @@ describe('handleEvent', () => {
 
     it('service point is missing receives AccessModal', () => {
       const config = {
+        metadata: {
+          requests: {
+            subscribesTo: ['servicepoints'],
+          },
+        },
         okapi: {
           currentUser: {
             curServicePoint: null,


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UISP-32 on login, insert service point details into the session
-->

## Description
If a user doesn't have a service point assigned and attempts to open a module that requires one, the `Access Denied` modal should appear. Previously, the list of modules that trigger this modal was hardcoded in `ui-servicepoints`. After this PR is merged, modules that require this behavior must declare it in their `package.json::stripes` by adding ["subscribesTo": ["servicepoints"]](https://github.com/folio-org/ui-reading-room/blob/master/package.json#L15).

## Issues
https://folio-org.atlassian.net/browse/UISP-53

## Related PRs
https://github.com/folio-org/stripes-webpack/pull/174
https://github.com/folio-org/ui-reading-room/pull/64
https://github.com/folio-org/ui-checkin/pull/717
https://github.com/folio-org/ui-checkout/pull/950
https://github.com/folio-org/ui-requests/pull/1350
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UISP-32
 -->

## Screencasts

https://github.com/user-attachments/assets/789c1c3d-df35-4c98-a7b2-65cfeab7a9ab



## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
