### PR TITLE
UISP-68: ChangeServicePoint - call onClose callback after closing the modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [9.0.0] IN PROGRESS
 
-* *BREAKING* Read a list of modules from `stripes.metadata` instead of a hard-coded list to display the "Access Denied" modal when a user does not have a service point assigned.
+* *BREAKING* Read a list of modules from `stripes.metadata` instead of a hard-coded list to display the "Access Denied" modal when a user does not have a service point assigned. UISP-53
+* ChangeServicePoint - call `onClose` callback after closing the modal. UISP-68
 
 ## [8.0.0](https://github.com/folio-org/ui-servicepoints/tree/v8.0.0) (2025-03-14)
 [Full Changelog](https://github.com/folio-org/ui-servicepoints/compare/v7.2.0...v8.0.0)

--- a/src/ChangeServicePoint/ChangeServicePoint.js
+++ b/src/ChangeServicePoint/ChangeServicePoint.js
@@ -15,7 +15,7 @@ export default class ChangeServicePoint extends React.Component {
 
   closeModal() {
     const { onClose } = this.props;
-    
+
     this.setState({ open: false });
 
     if (onClose) {

--- a/src/ChangeServicePoint/ChangeServicePoint.js
+++ b/src/ChangeServicePoint/ChangeServicePoint.js
@@ -14,7 +14,13 @@ export default class ChangeServicePoint extends React.Component {
   }
 
   closeModal() {
+    const { onClose } = this.props;
+    
     this.setState({ open: false });
+
+    if (onClose) {
+      onClose();
+    }
   }
 
   render() {


### PR DESCRIPTION
## Purpose
`ChangeServicePoint` - call `onClose` callback after closing the modal.

## Issues

[UISP-68](https://folio-org.atlassian.net/browse/UISP-68)